### PR TITLE
fix: upgrade LLMStrategy to support LanguageModelV3 (AI SDK 6) (fixes #5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,21 +86,21 @@
   "dependencies": {
     "@opentelemetry/core": "^2.2.0",
     "@opentelemetry/sdk-trace-base": "^2.2.0",
-    "@polar-sh/sdk": "^0.41.5"
+    "@polar-sh/sdk": "^0.42.4"
   },
   "peerDependencies": {
     "@aws-sdk/client-s3": "^3.744.0",
-    "ai": "^5.0.18"
+    "ai": "^6.0.57"
   },
   "devDependencies": {
-    "@ai-sdk/provider": "^2.0.0",
+    "@ai-sdk/provider": "^3.0.5",
     "@aws-sdk/client-s3": "^3.800.0",
     "@biomejs/biome": "1.9.4",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/sdk-trace-node": "^2.2.0",
     "@sindresorhus/tsconfig": "^7.0.0",
     "@types/node": "^22.15.3",
-    "ai": "^5.0.18",
+    "ai": "^6.0.57",
     "tsup": "^8.4.0",
     "typescript": "^5.8.3",
     "vitest": "^3.2.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,12 +15,12 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0(@opentelemetry/api@1.9.0)
       '@polar-sh/sdk':
-        specifier: ^0.41.5
-        version: 0.41.5
+        specifier: ^0.42.4
+        version: 0.42.4
     devDependencies:
       '@ai-sdk/provider':
-        specifier: ^2.0.0
-        version: 2.0.0
+        specifier: ^3.0.5
+        version: 3.0.5
       '@aws-sdk/client-s3':
         specifier: ^3.800.0
         version: 3.864.0
@@ -40,8 +40,8 @@ importers:
         specifier: ^22.15.3
         version: 22.17.2
       ai:
-        specifier: ^5.0.18
-        version: 5.0.18(zod@3.25.76)
+        specifier: ^6.0.57
+        version: 6.0.57(zod@3.25.76)
       tsup:
         specifier: ^8.4.0
         version: 8.5.0(postcss@8.5.6)(typescript@5.9.2)
@@ -54,20 +54,20 @@ importers:
 
 packages:
 
-  '@ai-sdk/gateway@1.0.9':
-    resolution: {integrity: sha512-kIfwunyUUwyBLg2KQcaRtjRQ1bDuJYPNIs4CNWaWPpMZ4SV5cRL1hLGMuX4bhfCJYDXHMGvJGLtUK6+iAJH2ZQ==}
+  '@ai-sdk/gateway@3.0.25':
+    resolution: {integrity: sha512-j0AQeA7hOVqwImykQlganf/Euj3uEXf0h3G0O4qKTDpEwE+EZGIPnVimCWht5W91lAetPZSfavDyvfpuPDd2PQ==}
     engines: {node: '>=18'}
     peerDependencies:
-      zod: ^3.25.76 || ^4
+      zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@3.0.4':
-    resolution: {integrity: sha512-/3Z6lfUp8r+ewFd9yzHkCmPlMOJUXup2Sx3aoUyrdXLhOmAfHRl6Z4lDbIdV0uvw/QYoBcVLJnvXN7ncYeS3uQ==}
+  '@ai-sdk/provider-utils@4.0.10':
+    resolution: {integrity: sha512-VeDAiCH+ZK8Xs4hb9Cw7pHlujWNL52RKe8TExOkrw6Ir1AmfajBZTb9XUdKOZO08RwQElIKA8+Ltm+Gqfo8djQ==}
     engines: {node: '>=18'}
     peerDependencies:
-      zod: ^3.25.76 || ^4
+      zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider@2.0.0':
-    resolution: {integrity: sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==}
+  '@ai-sdk/provider@3.0.5':
+    resolution: {integrity: sha512-2Xmoq6DBJqmSl80U6V9z5jJSJP7ehaJJQMy2iFUqTay06wdCqTnPVBBQbtEL8RCChenL+q5DC5H5WzU3vV3v8w==}
     engines: {node: '>=18'}
 
   '@aws-crypto/crc32@5.2.0':
@@ -489,8 +489,8 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@polar-sh/sdk@0.41.5':
-    resolution: {integrity: sha512-E+VoVV+WvebZKmj+KZ/fj1byBZbG7J8hHyzYD9kktvAToigPM19sywo2tFCHeb44aWGCVACMOP8r31e6je7dxA==}
+  '@polar-sh/sdk@0.42.4':
+    resolution: {integrity: sha512-wZueAFJ7C+Q5ZDBnkE5lNcqr4DFGazfQWoUmVnZDRUgnq5g3kXUspPQYUS86y9XlL4szXXdT/LUcMwIZq4mgWw==}
 
   '@rollup/rollup-android-arm-eabi@4.46.4':
     resolution: {integrity: sha512-B2wfzCJ+ps/OBzRjeds7DlJumCU3rXMxJJS1vzURyj7+KBHGONm7c9q1TfdBl4vCuNMkDvARn3PBl2wZzuR5mw==}
@@ -811,8 +811,8 @@ packages:
   '@stablelib/base64@1.0.1':
     resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
-  '@standard-schema/spec@1.0.0':
-    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
@@ -828,6 +828,10 @@ packages:
 
   '@types/uuid@9.0.8':
     resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
+
+  '@vercel/oidc@3.1.0':
+    resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
+    engines: {node: '>= 20'}
 
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
@@ -863,11 +867,11 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  ai@5.0.18:
-    resolution: {integrity: sha512-fx5RqO0e+wB/dd/pbtCvx2j5WT1UYXSeONyMCgej0s6neCEhh9Wv5OmZHk6yxWKqI0y6WyjEqxCp8VCIqNZTDg==}
+  ai@6.0.57:
+    resolution: {integrity: sha512-5wYcMQmOaNU71wGv4XX1db3zvn4uLjLbTKIo6cQZPWOJElA0882XI7Eawx6TCd5jbjOvKMIP+KLWbpVomAFT2g==}
     engines: {node: '>=18'}
     peerDependencies:
-      zod: ^3.25.76 || ^4
+      zod: ^3.25.76 || ^4.1.8
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -978,9 +982,9 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
-  eventsource-parser@3.0.5:
-    resolution: {integrity: sha512-bSRG85ZrMdmWtm7qkF9He9TNRzc/Bm99gEJMaQoHJ9E6Kv9QBbsldh2oMj7iXmYNEAVvNgvv5vPorG6W+XtBhQ==}
-    engines: {node: '>=20.0.0'}
+  eventsource-parser@3.0.6:
+    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
 
   expect-type@1.2.2:
     resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
@@ -1390,31 +1394,26 @@ packages:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
 
-  zod-to-json-schema@3.24.6:
-    resolution: {integrity: sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==}
-    peerDependencies:
-      zod: ^3.24.1
-
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
 
-  '@ai-sdk/gateway@1.0.9(zod@3.25.76)':
+  '@ai-sdk/gateway@3.0.25(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.4(zod@3.25.76)
+      '@ai-sdk/provider': 3.0.5
+      '@ai-sdk/provider-utils': 4.0.10(zod@3.25.76)
+      '@vercel/oidc': 3.1.0
       zod: 3.25.76
 
-  '@ai-sdk/provider-utils@3.0.4(zod@3.25.76)':
+  '@ai-sdk/provider-utils@4.0.10(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 2.0.0
-      '@standard-schema/spec': 1.0.0
-      eventsource-parser: 3.0.5
+      '@ai-sdk/provider': 3.0.5
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
       zod: 3.25.76
-      zod-to-json-schema: 3.24.6(zod@3.25.76)
 
-  '@ai-sdk/provider@2.0.0':
+  '@ai-sdk/provider@3.0.5':
     dependencies:
       json-schema: 0.4.0
 
@@ -2056,7 +2055,7 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@polar-sh/sdk@0.41.5':
+  '@polar-sh/sdk@0.42.4':
     dependencies:
       standardwebhooks: 1.0.0
       zod: 3.25.76
@@ -2461,7 +2460,7 @@ snapshots:
 
   '@stablelib/base64@1.0.1': {}
 
-  '@standard-schema/spec@1.0.0': {}
+  '@standard-schema/spec@1.1.0': {}
 
   '@types/chai@5.2.2':
     dependencies:
@@ -2476,6 +2475,8 @@ snapshots:
       undici-types: 6.21.0
 
   '@types/uuid@9.0.8': {}
+
+  '@vercel/oidc@3.1.0': {}
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -2521,11 +2522,11 @@ snapshots:
 
   acorn@8.15.0: {}
 
-  ai@5.0.18(zod@3.25.76):
+  ai@6.0.57(zod@3.25.76):
     dependencies:
-      '@ai-sdk/gateway': 1.0.9(zod@3.25.76)
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.4(zod@3.25.76)
+      '@ai-sdk/gateway': 3.0.25(zod@3.25.76)
+      '@ai-sdk/provider': 3.0.5
+      '@ai-sdk/provider-utils': 4.0.10(zod@3.25.76)
       '@opentelemetry/api': 1.9.0
       zod: 3.25.76
 
@@ -2637,7 +2638,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
-  eventsource-parser@3.0.5: {}
+  eventsource-parser@3.0.6: {}
 
   expect-type@1.2.2: {}
 
@@ -3032,9 +3033,5 @@ snapshots:
       ansi-styles: 6.2.1
       string-width: 5.1.2
       strip-ansi: 7.1.0
-
-  zod-to-json-schema@3.24.6(zod@3.25.76):
-    dependencies:
-      zod: 3.25.76
 
   zod@3.25.76: {}

--- a/src/strategies/LLM/index.test.ts
+++ b/src/strategies/LLM/index.test.ts
@@ -20,16 +20,24 @@ vi.mock("@polar-sh/sdk", async (importOriginal) => {
 import { Ingestion } from "../../ingestion";
 
 const mockLLMClient = {
-  specificationVersion: "v2",
+  specificationVersion: "v3",
   provider: "test-provider",
   modelId: "test-model",
   defaultObjectGenerationMode: "json",
   supportedUrls: {},
   doGenerate: vi.fn().mockResolvedValue({
     usage: {
-      inputTokens: 1,
-      outputTokens: 1,
-      totalTokens: 2,
+      inputTokens: {
+        total: 1,
+        noCache: 1,
+        cacheRead: 0,
+        cacheWrite: 0,
+      },
+      outputTokens: {
+        total: 1,
+        text: 1,
+        reasoning: 0,
+      },
       model: "test-model",
       vendor: "test-provider",
     },

--- a/src/strategies/LLM/index.ts
+++ b/src/strategies/LLM/index.ts
@@ -1,8 +1,10 @@
 import type {
-  LanguageModelV2,
-  LanguageModelV2CallOptions,
-  LanguageModelV2StreamPart,
+  LanguageModelV3,
+  LanguageModelV3CallOptions,
+  LanguageModelV3StreamPart
 } from "@ai-sdk/provider";
+import type { CostMetadataInput } from "@polar-sh/sdk/models/components/costmetadatainput.js";
+import type { LLMMetadata } from "@polar-sh/sdk/models/components/llmmetadata.js";
 import { type LanguageModelMiddleware, wrapLanguageModel } from "ai";
 import type { IngestionContext } from "../../ingestion";
 import {
@@ -11,16 +13,14 @@ import {
   type IngestionStrategyCustomer,
   type IngestionStrategyExternalCustomer,
 } from "../../strategy";
-import type { CostMetadataInput } from "@polar-sh/sdk/models/components/costmetadatainput.js";
-import type { LLMMetadata } from "@polar-sh/sdk/models/components/llmmetadata.js";
 
 export type LLMStrategyContext = IngestionContext<{
   inputTokens: number;
   outputTokens: number;
   totalTokens: number;
   cachedInputTokens: number;
-  vendor: LanguageModelV2["provider"];
-  model: LanguageModelV2["modelId"];
+  vendor: LanguageModelV3["provider"];
+  model: LanguageModelV3["modelId"];
   strategy: "LLM";
   _llm: LLMMetadata;
   _cost?: CostMetadataInput;
@@ -30,11 +30,11 @@ export type CostResolver = (context: LLMStrategyContext) => CostMetadataInput;
 
 export class LLMStrategy extends IngestionStrategy<
   LLMStrategyContext,
-  LanguageModelV2
+  LanguageModelV3
 > {
-  private model: LanguageModelV2;
+  private model: LanguageModelV3;
 
-  constructor(model: LanguageModelV2) {
+  constructor(model: LanguageModelV3) {
     super();
 
     this.model = model;
@@ -42,30 +42,30 @@ export class LLMStrategy extends IngestionStrategy<
 
   private middleware(
     execute: IngestionExecutionHandler<LLMStrategyContext>,
-    customer: IngestionStrategyCustomer | IngestionStrategyExternalCustomer
+    customer: IngestionStrategyCustomer | IngestionStrategyExternalCustomer,
   ): LanguageModelMiddleware {
     const wrapGenerate = async (options: {
-      doGenerate: () => ReturnType<LanguageModelV2["doGenerate"]>;
-      params: LanguageModelV2CallOptions;
-      model: LanguageModelV2;
-    }): Promise<Awaited<ReturnType<LanguageModelV2["doGenerate"]>>> => {
+      doGenerate: () => ReturnType<LanguageModelV3["doGenerate"]>;
+      params: LanguageModelV3CallOptions;
+      model: LanguageModelV3;
+    }): Promise<Awaited<ReturnType<LanguageModelV3["doGenerate"]>>> => {
       const result = await options.doGenerate();
 
       const llmEvent: LLMStrategyContext = {
         vendor: this.model.provider,
         model: this.model.modelId,
-        inputTokens: result.usage.inputTokens ?? 0,
-        cachedInputTokens: result.usage.cachedInputTokens ?? 0,
-        outputTokens: result.usage.outputTokens ?? 0,
-        totalTokens: result.usage.totalTokens ?? 0,
+        inputTokens: result.usage.inputTokens.total ?? 0,
+        cachedInputTokens: result.usage.inputTokens.cacheRead ?? 0,
+        outputTokens: result.usage.outputTokens.total ?? 0,
+        totalTokens: (result.usage.inputTokens.total ?? 0) + (result.usage.outputTokens.total ?? 0),
         strategy: "LLM",
         _llm: {
           vendor: this.model.provider,
           model: this.model.modelId,
-          inputTokens: result.usage.inputTokens ?? 0,
-          cachedInputTokens: result.usage.cachedInputTokens ?? 0,
-          outputTokens: result.usage.outputTokens ?? 0,
-          totalTokens: result.usage.totalTokens ?? 0,
+          inputTokens: result.usage.inputTokens.total ?? 0,
+          cachedInputTokens: result.usage.inputTokens.cacheRead ?? 0,
+          outputTokens: result.usage.outputTokens.total ?? 0,
+          totalTokens: (result.usage.inputTokens.total ?? 0) + (result.usage.outputTokens.total ?? 0),
         },
       };
 
@@ -77,33 +77,33 @@ export class LLMStrategy extends IngestionStrategy<
     const wrapStream = async ({
       doStream,
     }: {
-      doStream: () => ReturnType<LanguageModelV2["doStream"]>;
-      params: LanguageModelV2CallOptions;
-      model: LanguageModelV2;
+      doStream: () => ReturnType<LanguageModelV3["doStream"]>;
+      params: LanguageModelV3CallOptions;
+      model: LanguageModelV3;
     }) => {
       const { stream, ...rest } = await doStream();
 
       const transformStream = new TransformStream<
-        LanguageModelV2StreamPart,
-        LanguageModelV2StreamPart
+        LanguageModelV3StreamPart,
+        LanguageModelV3StreamPart
       >({
         transform: async (chunk, controller) => {
           if (chunk.type === "finish") {
             const llmEvent: LLMStrategyContext = {
               vendor: this.model.provider,
               model: this.model.modelId,
-              inputTokens: chunk.usage.inputTokens ?? 0,
-              cachedInputTokens: chunk.usage.cachedInputTokens ?? 0,
-              outputTokens: chunk.usage.outputTokens ?? 0,
-              totalTokens: chunk.usage.totalTokens ?? 0,
+              inputTokens: chunk.usage.inputTokens.total ?? 0,
+              cachedInputTokens: chunk.usage.inputTokens.cacheRead ?? 0,
+              outputTokens: chunk.usage.outputTokens.total ?? 0,
+              totalTokens: (chunk.usage.inputTokens.total ?? 0) + (chunk.usage.outputTokens.total ?? 0),
               strategy: "LLM",
               _llm: {
                 vendor: this.model.provider,
                 model: this.model.modelId,
-                inputTokens: chunk.usage.inputTokens ?? 0,
-                cachedInputTokens: chunk.usage.cachedInputTokens ?? 0,
-                outputTokens: chunk.usage.outputTokens ?? 0,
-                totalTokens: chunk.usage.totalTokens ?? 0,
+                inputTokens: chunk.usage.inputTokens.total ?? 0,
+                cachedInputTokens: chunk.usage.inputTokens.cacheRead ?? 0,
+                outputTokens: chunk.usage.outputTokens.total ?? 0,
+                totalTokens: (chunk.usage.inputTokens.total ?? 0) + (chunk.usage.outputTokens.total ?? 0),
               },
             };
 
@@ -121,14 +121,15 @@ export class LLMStrategy extends IngestionStrategy<
     };
 
     return {
+      specificationVersion: "v3",
       wrapGenerate,
       wrapStream,
     };
   }
 
   override client(
-    customer: IngestionStrategyCustomer | IngestionStrategyExternalCustomer
-  ): LanguageModelV2 {
+    customer: IngestionStrategyCustomer | IngestionStrategyExternalCustomer,
+  ): LanguageModelV3 {
     const executionHandler = this.createExecutionHandler();
 
     return wrapLanguageModel({


### PR DESCRIPTION
## Summary
Updates [LLMStrategy](cci:2://file:///Users/abhay/Desktop/Code/polar-ingestion/src/strategies/LLM/index.ts:30:0-139:1) to fully support `LanguageModelV3` introduced in Vercel AI SDK 6, resolving type incompatibility issues reported in #5.

## Changes
- **Updated [LLMStrategy](cci:2://file:///Users/abhay/Desktop/Code/polar-ingestion/src/strategies/LLM/index.ts:30:0-139:1)**: Now correctly implements `LanguageModelV3`.
- **Token Usage Extraction**: Adapted to the new nested `LanguageModelV3Usage` structure (e.g., extracting `.total` from `inputTokens` and `outputTokens`) instead of the flat structure from V2.
- **Middleware Update**: Bumped middleware `specificationVersion` to `"v3"` to match the provider requirements.
- **Tests**: Updated unit tests and mocks to reflect the new V3 usage structure and specification.

## Why
The recent release of Vercel AI SDK 6 changed the provider interface to `LanguageModelV3`, which introduced breaking changes to how token usage is reported (moving from flat numbers to nested objects). This caused TypeScript errors when using modern providers (like `@ai-sdk/google` v3) with [LLMStrategy](cci:2://file:///Users/abhay/Desktop/Code/polar-ingestion/src/strategies/LLM/index.ts:30:0-139:1).

## Impact
- **Internal**: [LLMStrategy](cci:2://file:///Users/abhay/Desktop/Code/polar-ingestion/src/strategies/LLM/index.ts:30:0-139:1) now requires a V3-compatible provider.
- **Consumer**: [LLMStrategyContext](cci:2://file:///Users/abhay/Desktop/Code/polar-ingestion/src/strategies/LLM/index.ts:16:0-26:3) remains backward compatible. Users of the ingestion strategy will still receive flattened token counts (`inputTokens`, `outputTokens`, etc.) as numbers, just as before.

## Related Issue
Fixes #5